### PR TITLE
README: Fix typo in branch name

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@ We try to contribute back to the alpine linux project, but we probably
 always need some functionality that can't make it into the official tree.
 Anyhow, we really try to keep our extras as small and limited as possible.
 
-We use https://github.com/rgerhards/docker-alpine-abuild/tree/master-rger
+We use https://github.com/rgerhards/docker-alpine-abuild/tree/master-rsyslog
 to build the packages.


### PR DESCRIPTION
I assume that the original branch was moved/renamed and while I wasn't sure which of the two remaining branches you meant to link to I guessed 'master' (instead of 'master-rsyslog').